### PR TITLE
Fix mount path resolving in example_wrapper.sh

### DIFF
--- a/example_wrapper.sh
+++ b/example_wrapper.sh
@@ -159,7 +159,7 @@ if ! $WRITABLE; then
     if test -e ${SOURCE[$i]}; then
 
       FULL_SOURCE=$( realpath -e ${SOURCE[$i]} )
-      FULL_DESTINATION=$( realpath -m ${DESTINATION[$i]} )
+      FULL_DESTINATION=$( realpath -ms ${DESTINATION[$i]} )
 
       MOUNT_ARG="$MOUNT_ARG --mount ${TYPE[$i]},source=$FULL_SOURCE,destination=$FULL_DESTINATION"
 


### PR DESCRIPTION
This pull request resolves the following issue, where mounting a symlink using the example wrapper results in unexpected bahaviour.

If I have a symlink `/path/to/symlink/` that points to directory `/path/to/dir/` and try to mount it into the container by adding
```bash
"type=bind" "/path/to/symlink/" "/path/to/symlink/"
```
to the MOUNTS variable, I would assume that the path inside container will be `/path/to/symlink/`. However, the symlink is resolved and it is placed into `/path/to/dir/` instead.

This problem is even more strange, when the target corresponds to a random symlink inside the host system - the symlink is resolved and as a result, the mount is placed into a seemingly random location.

My fix disables resolving of symlinks for the target mount point as they are not relevant to the file system inside of the container. (Symlinks for the source directory are still resolved.)

This also fixes problems with X11 apps not working under some versions of WSL2, where `/tmp/.X11-unix/` is symlink.

